### PR TITLE
Fix async event issue

### DIFF
--- a/src/main/kotlin/org/kalasim/misc/AsyncEventListener.kt
+++ b/src/main/kotlin/org/kalasim/misc/AsyncEventListener.kt
@@ -4,8 +4,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.kalasim.Event
 import org.kalasim.EventListener
 
@@ -14,19 +16,25 @@ class AsyncEventListener(val scope: CoroutineScope = GlobalScope) : EventListene
 
     inline fun <reified T : Event> start(crossinline block: (event: T) -> Unit) {
         scope.launch {
-            eventChannel.receiveAsFlow()
-                .collect { event: Event ->
-                    println("received event ${event}")
-                    if (event is T)
-                        block.invoke(event)
-                }
+            eventChannel
+                .receiveAsFlow()
+                //.onEach { println("received event ${it::class.simpleName}") }
+                .filter { it is T }
+                .collect { event: Event -> block.invoke(event as T) }
         }
     }
 
     override fun consume(event: Event) {
-        scope.launch {
-//            println("adding event ${event} to channel")
-            eventChannel.trySend(event)
+        runBlocking {
+            launch {
+                println("adding event $event to channel")
+                eventChannel.trySend(event)
+                    .also { result ->
+                        println("result: $result")
+                        if (result.isFailure)
+                            println("Failed to add event $event to channel")
+                    }
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes the async even problem by using a `runBlocking` context to submit the events.  

With regard to your second question, yes, I believe a flow can be collected only once. 
I think I know what you are getting at with your question. 

If you allow for multiple listeners to be added in the same call then you will be able to share
the flow. Something like:
```kotlin
addAsyncEventListeners {
    onEvent<EntityCreatedEvent> { ... }
    onEvent<MetricEvent> { ... }
    onEvent<TimerEvent> { ... }
}
```